### PR TITLE
API Endpoint proxy Issue

### DIFF
--- a/ui/src/api/auth.js
+++ b/ui/src/api/auth.js
@@ -1,6 +1,6 @@
 import { getCookie } from './cookie';
 //0735 096 284
-export let apiHost = (process.env['REACT_APP_NODE_ENV'] === "dev") ? 'http://localhost:8080' : '/api';
+export let apiHost = (process.env['REACT_APP_NODE_ENV'] === "dev") ? 'http://localhost:8080' : '';
 
 export let LDAPApi = async(params) => {
 


### PR DESCRIPTION
```export let apiHost = (process.env['REACT_APP_NODE_ENV'] === "dev") ? 'http://localhost:8080' : '';```


The issue with Login because of apiHost rediirection on prod